### PR TITLE
Add poppler-utils dependency and eng language default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-slim-buster
 
 RUN apt-get update \
-&& apt-get install --yes --no-install-recommends ffmpeg libsm6 libxext6 tesseract-ocr tesseract-ocr-nld \
+&& apt-get install --yes --no-install-recommends ffmpeg libsm6 libxext6 tesseract-ocr poppler-utils tesseract-ocr-eng \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For a quick installation, there is a docker version available. See the examples 
 
 If you don't like docker, there is the manual installation option.
 If you already installed [rest_uploader](https://github.com/kellerjustin/rest-uploader) you probably almost setup already.
-All that is left is to install this scrip and setup the environment variables.
+All that is left is to install this script and setup the environment variables.
 
 ```shell
 pip install ocr-joplin-notes

--- a/ocr_joplin_notes/file_ocr.py
+++ b/ocr_joplin_notes/file_ocr.py
@@ -6,9 +6,16 @@ import cv2
 import numpy as np
 
 import PyPDF2
+import PIL
+
+#all various attempts to fix the problem below
 #from PIL import Image # original code
-from PIL import Image Image.MAX_IMAGE_PIXELS = 1000000000
+#from PIL import Image Image.MAX_IMAGE_PIXELS = 1000000000
 #Image.MAX_IMAGE_PIXELS = None #something else I read to try
+
+import PIL.Image
+PIL.Image.MAX_IMAGE_PIXELS = 1000000000
+
 from pdf2image import convert_from_path
 from pytesseract import image_to_string, TesseractError
 

--- a/ocr_joplin_notes/file_ocr.py
+++ b/ocr_joplin_notes/file_ocr.py
@@ -6,10 +6,12 @@ import cv2
 import numpy as np
 
 import PyPDF2
-from PIL import Image
+#from PIL import Image # original code
+from PIL import Image Image.MAX_IMAGE_PIXELS = 1000000000
+#Image.MAX_IMAGE_PIXELS = None #something else I read to try
 from pdf2image import convert_from_path
 from pytesseract import image_to_string, TesseractError
-Image.MAX_IMAGE_PIXELS = None
+
 
 class FileOcrResult:
     def __init__(self, pages):

--- a/ocr_joplin_notes/file_ocr.py
+++ b/ocr_joplin_notes/file_ocr.py
@@ -9,7 +9,7 @@ import PyPDF2
 from PIL import Image
 from pdf2image import convert_from_path
 from pytesseract import image_to_string, TesseractError
-
+PIL.Image.MAX_IMAGE_PIXELS = None
 
 class FileOcrResult:
     def __init__(self, pages):

--- a/ocr_joplin_notes/file_ocr.py
+++ b/ocr_joplin_notes/file_ocr.py
@@ -9,7 +9,7 @@ import PyPDF2
 from PIL import Image
 from pdf2image import convert_from_path
 from pytesseract import image_to_string, TesseractError
-PIL.Image.MAX_IMAGE_PIXELS = None
+Image.MAX_IMAGE_PIXELS = None
 
 class FileOcrResult:
     def __init__(self, pages):

--- a/ocr_joplin_notes/file_ocr.py
+++ b/ocr_joplin_notes/file_ocr.py
@@ -1,7 +1,7 @@
-import logging
-import os
-import tempfile
-from uuid import uuid4
+#import logging
+#import os
+#import tempfile
+#from uuid import uuid4
 import cv2
 import numpy as np
 


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/plamola/ocr-joplin-notes/issues/7), some of my PDFs were still returning errors due to this missing dependency.  I've updated the Dockerfile to fix this problem as well as to install tesseract-ocr-eng instead of -nld.  I wasn't sure why the -nld was referenced since the script said that eng was the default.  Please let me know if changing this part was an error.